### PR TITLE
feat: increase connection and server selection timeout to 60s

### DIFF
--- a/package/src/swagger_server/controllers/db.py
+++ b/package/src/swagger_server/controllers/db.py
@@ -3,10 +3,12 @@ from os import environ as env
 from pymongo import MongoClient
 
 CLIENT = MongoClient(
-  'mongodb://mongodb:27017/', 
-  username=env.get('MONGO_USERNAME'), 
-  password=env.get('MONGO_PASSWORD')
-  )
+    'mongodb://mongodb:27017/',
+    username=env.get('MONGO_USERNAME'),
+    password=env.get('MONGO_PASSWORD'),
+    connectTimeoutMS=60000,
+    serverSelectionTimeoutMS=60000
+)
 DB = CLIENT.database
 query_details = DB.query_db
-student_details =  DB.student_db
+student_details = DB.student_db


### PR DESCRIPTION
### Context
https://scalegrid.io/blog/understanding-mongodb-client-timeout-options/#:~:text=Mongo%20driver%20uses%2030s%20as,increase%20or%20decrease%20this%20threshold.

Default mongodb drivers have the following default timeouts:
```
         - `connectTimeoutMS`: (integer or None) Controls how long (in
            milliseconds) the driver will wait during server monitoring when
            connecting a new socket to a server before concluding the server
            is unavailable. ``0`` or ``None`` means no timeout.
            Defaults to ``20000`` (20 seconds).
          - `serverSelectionTimeoutMS`: (integer) Controls how long (in
            milliseconds) the driver will wait to find an available,
            appropriate server to carry out a database operation; while it is
            waiting, multiple server monitoring operations may be carried out,
            each controlled by `connectTimeoutMS`. Defaults to ``30000`` (30
            seconds).
```

### Graphql Error
```
{
  "errors": [
    {
      "message": "Internal Server Error",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "quote"
      ],
      "extensions": {
        "innerError": {
          "message": "Request failed with status code 502",
          "name": "Error",
          "stack": "Error: Request failed with status code 502\n    at createError (/app/.yarn/cache/axios-npm-0.21.1-d192f6b3b3-c87915fa0b.zip/node_modules/axios/lib/core/createError.js:16:15)\n    at settle (/app/.yarn/cache/axios-npm-0.21.1-d192f6b3b3-c87915fa0b.zip/node_medodules/axios/lib/core/settle.js:17:12)\n    at IncomingMessage.handleStreamEnd (/app/.yarn/cache/axios-npm-0.21.1-d192f6b3b3-c87915fa0b.zip/node_modules/axios/lib/adapters/http.js:260:11)\n    at IncomingMessage.emit (node:events:532:35)\n    at IncomingMessage.emit (node:domain:475:12)\n    at endReadableNT (node:internal/streams/readable:1346:12)\n    at processTicksAndRejections (node:internal/process/task_queues:83:21)",
          "config": {
            "url": "/dry_run/degree",
            "method": "post",
            "data": "{\"customer_id\":\"dry-run\",\"event\":{\"address\":\"testing\",\"end_date\":\"2023-02-13 15:30\",\"info...\",\"absolute\":100,\"percentage\":0,\"race\":[],\"gender\":[],\"average\":0,\"smsMessage\":null,\"degree_name\":\"\"}]}}",
            "headers": {
              "Accept": "application/json, text/plain, */*",
              "Content-Type": "application/json;charset=utf-8",
              "Authorization": "Bearer  123",
              "User-Agent": "axios/0.21.1",
              "Content-Length": 11203
            },
            "baseURL": "https://demoapi.registree.io:2053/querydb",
            "transformRequest": [
              null
            ],
            "transformResponse": [
              null
            ],
            "timeout": 0,
            "xsrfCookieName": "XSRF-TOKEN",
            "xsrfHeaderName": "X-XSRF-TOKEN",
            "maxContentLength": -1,
            "maxBodyLength": -1
          }
        },
        "code": "INTERNAL_SERVER_ERROR",
        "exception": {
          "innerError": {
            "message": "Request failed with status code 502",
            "name": "Error",
            "stack": "Error: Request failed with status code 502\n    at createError (/app/.yarn/cache/axios-npm-0.21.1-d192f6b3b3-c87915fa0b.zip/node_modules/axios/lib/core/createError.js:16:15)\n    at settle (/app/.yarn/cache/axios-npm-0.21.1-d192f6b3b3-c87915fa0b.zip/node_modules/axios/lib/core/settle.js:17:12)\n    at IncomingMessage.handleStreamEnd (/app/.yarn/cache/axios-npm-0.21.1-d192f6b3b3-c87915fa0b.zip/node_modules/axios/lib/adapters/http.js:260:11)\n    at IncomingMessage.emit (node:events:532:35)\n    at IncomingMessage.emit (node:domain:475:12)\n    at endReadableNT (node:internal/streams/readable:1346:12)\n    at processTicksAndRejections (node:internal/process/task_queues:83:21)",
            "config": {
              "url": "/dry_run/degree",
              "method": "post",
              "data": "...:\"\"}]}}",
              "headers": {
                "Accept": "application/json, text/plain, */*",
                "Content-Type": "application/json;charset=utf-8",
                "Authorization": "Bearer ...",
                "User-Agent": "axios/0.21.1",
                "Content-Length": 11203
              },
              "baseURL": "https://demoapi.registree.io:2053/querydb",
              "transformRequest": [
                null
              ],
              "transformResponse": [
                null
              ],
              "timeout": 0,
              "xsrfCookieName": "XSRF-TOKEN",
              "xsrfHeaderName": "X-XSRF-TOKEN",
              "maxContentLength": -1,
              "maxBodyLength": -1
            }
          },
          "stacktrace": [
            "Error: Internal Server Error",
            "    at AllExceptionsFilter.handleUnexpectedError (/app/dist/all-exceptions.filter.js:61:20)",
            "    at AllExceptionsFilter.handleGqlError (/app/dist/all-exceptions.filter.js:45:25)",
..."
          ]
        }
      }
    }
  ],
  "data": null
}
```