### PR TITLE
build: update git:// to https://

### DIFF
--- a/package/setup.py
+++ b/package/setup.py
@@ -15,7 +15,7 @@ setup(
       'connexion[swagger-ui]', 
       'flask_cors', 
       'pymongo', 
-      'registree-auth @ git+git://github.com/registreerocks/registree-auth.git'
+      'registree-auth @ git+https://github.com/registreerocks/registree-auth.git'
       ],
    test_require=['pytest', 'mock', 'freezegun']
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pymongo
 pytest
 freezegun
 mock
-git+git://github.com/registreerocks/registree-auth.git
+git+https://github.com/registreerocks/registree-auth.git


### PR DESCRIPTION
https://stackoverflow.com/questions/72915782/fatal-unable-to-connect-to-github-com-github-com0-140-82-121-3-errno-opera
https://stackoverflow.com/questions/32688688/how-to-write-setup-py-to-include-a-git-repository-as-a-dependency

To make `docker-compose build` work. Was getting the following error:
```
=> ERROR [ 8/12] RUN pip install -e .                                                                                                                                   134.6s
------
 > [ 8/12] RUN pip install -e .:
#12 1.239 Obtaining file:///usr/src/package
#12 1.516 Collecting registree-auth@ git+git://github.com/registreerocks/registree-auth.git
#12 1.516   Cloning git://github.com/registreerocks/registree-auth.git to /tmp/pip-install-62m4maqc/registree-auth_14bea87d3aa64e709172c9804acd8f30
#12 1.516   Running command git clone -q git://github.com/registreerocks/registree-auth.git /tmp/pip-install-62m4maqc/registree-auth_14bea87d3aa64e709172c9804acd8f30
#12 132.5   fatal: unable to connect to github.com:
#12 132.5   github.com[0: 140.82.121.4]: errno=Connection timed out
#12 132.5
#12 132.6 WARNING: Discarding git+git://github.com/registreerocks/registree-auth.git. Command errored out with exit status 128: git clone -q git://github.com/registreerocks/registree-auth.git /tmp/pip-install-62m4maqc/registree-auth_14bea87d3aa64e709172c9804acd8f30 Check the logs for full command output.
#12 132.8 Collecting connexion[swagger-ui]
#12 132.9   Downloading connexion-2.14.2-py2.py3-none-any.whl (95 kB)
#12 133.1 Collecting flask_cors
#12 133.1   Downloading Flask_Cors-3.0.10-py2.py3-none-any.whl (14 kB)
#12 134.0 Collecting pymongo
#12 134.0   Downloading pymongo-4.1.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (462 kB)
#12 134.4 ERROR: Could not find a version that satisfies the requirement registree-auth (unavailable) (from query-db) (from versions: none)
#12 134.4 ERROR: No matching distribution found for registree-auth (unavailable)
#12 134.5 WARNING: You are using pip version 21.2.4; however, version 21.3.1 is available.
#12 134.5 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
------
executor failed running [/bin/sh -c pip install -e .]: exit code: 1
ERROR: Service 'query_db_api' failed to build : Build failed
```