### PR TITLE
fix: increase gunicorn timeout to 60s

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 
 [program:gunicorn]
 directory=/usr/src/package/
-command=gunicorn swagger_server.__main__:app -b 0.0.0.0:8000
+command=gunicorn --timeout 60 swagger_server.__main__:app -b 0.0.0.0:8000
 autostart=true
 autorestart=true
 startsecs=10


### PR DESCRIPTION
Fix the following Graphql Internal Server Error 502:
```
2023/02/15 12:35:02 [error] 28#28: *4 upstream prematurely closed connection while reading response header from upstream, client: 162.158.87.181, server: _, request: "POST /querydb/dry_run/degree HTTP/1.1", upstream: "http://172.22.0.7:8000/dry_run/degree", host: "demoapi.registree.io:2053"
```

https://stackoverflow.com/questions/10855197/frequent-worker-timeout

https://app.clickup.com/t/862j4mw2n